### PR TITLE
[MRG] Strip excess segment padding

### DIFF
--- a/.github/workflows/pytest-builds.yml
+++ b/.github/workflows/pytest-builds.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -9,12 +9,12 @@ jobs:
     name: Build wheels for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
-      CIBW_SKIP: "cp35-*"
+      CIBW_SKIP: "cp36-*"
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.9]
+        python-version: ["3.10"]
 
     steps:
     - uses: actions/checkout@v2
@@ -35,7 +35,7 @@ jobs:
     - name: Install requirements
       run: |
         pip install -U pip
-        pip install cibuildwheel==1.10.0
+        pip install cibuildwheel==2.3.1
         pip install setuptools-rust
 
     - name: Build sdist

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 ## pylibjpeg-rle
 
-A fast DICOM ([PackBits](https://en.wikipedia.org/wiki/PackBits)) RLE plugin for [pylibjpeg](https://github.com/pydicom/pylibjpeg), written in Rust with a Python 3.6+ wrapper.
+A fast DICOM ([PackBits](https://en.wikipedia.org/wiki/PackBits)) RLE plugin for [pylibjpeg](https://github.com/pydicom/pylibjpeg), written in Rust with a Python 3.7+ wrapper.
 
 Linux, MacOS and Windows are all supported.
 

--- a/docs/release_notes/v1.2.0.rst
+++ b/docs/release_notes/v1.2.0.rst
@@ -1,0 +1,14 @@
+.. _v1.2.0:
+
+1.2.0
+=====
+
+Enhancements
+............
+
+* Support decoding segments with non-conformant padding (:issue:`7`)
+
+Changes
+.......
+
+* Support for Python 3.6 has been dropped, while Python 3.10 is now supported

--- a/rle/_version.py
+++ b/rle/_version.py
@@ -3,7 +3,7 @@
 import re
 
 
-__version__ = '1.1.0'
+__version__ = '1.2.0'
 
 
 VERSION_PATTERN = r"""

--- a/rle/tests/test_decode.py
+++ b/rle/tests/test_decode.py
@@ -834,3 +834,12 @@ class TestGenerateFrames:
         assert (600, 800) == arr.shape
         with pytest.raises(StopIteration):
             next(gen)
+
+    def test_multi_sample(self):
+        ds = deepcopy(INDEX["SC_rgb_rle_16bit.dcm"]['ds'])
+
+        gen = generate_frames(ds, reshape=True)
+        arr = next(gen)
+        assert (100, 100, 3) == arr.shape
+        with pytest.raises(StopIteration):
+            next(gen)

--- a/rle/tests/test_decode.py
+++ b/rle/tests/test_decode.py
@@ -136,25 +136,15 @@ class TestDecodeFrame:
         with pytest.raises(ValueError, match=msg):
             decode_frame(d + b'\x00' * 8, 1, 8, '<')
 
-    def test_insufficient_frame_literal_raises(self):
-        """Test exception if frame not large enough to hold segment on lit."""
-        msg = (
-            r"The end of the frame was reached before the segment was "
-            r"completely decoded"
-        )
+    def test_insufficient_frame_literal(self):
+        """Test segment with excess padding on lit."""
         d = self.as_bytes([64])
-        with pytest.raises(ValueError, match=msg):
-            decode_frame(d + b'\x00' * 8, 1, 8, '<')
+        assert decode_frame(d + b'\x00' * 8, 1, 8, '<') == b"\x00"
 
-    def test_insufficient_frame_copy_raises(self):
-        """Test exception if frame not large enough to hold segment on copy."""
-        msg = (
-            r"The end of the frame was reached before the segment was "
-            r"completely decoded"
-        )
+    def test_insufficient_frame_copy(self):
+        """Test segment withe excess padding on copy."""
         d = self.as_bytes([64])
-        with pytest.raises(ValueError, match=msg):
-            decode_frame(d + b'\xff\x00\x00', 1, 8, '<')
+        assert decode_frame(d + b'\xff\x00\x00', 1, 8, '<') == b"\x00"
 
     def test_insufficient_segment_copy_raises(self):
         """Test exception if insufficient segment data on copy."""

--- a/rle/tests/test_encode.py
+++ b/rle/tests/test_encode.py
@@ -245,8 +245,7 @@ class TestEncodeFrame:
         encoded = encode_frame(ds.PixelData, *params, '<')
         decoded = _rle_decode_frame(encoded, *params)
 
-        dtype = pixel_dtype(ds).newbyteorder('>')
-        arr = np.frombuffer(decoded, dtype)
+        arr = np.frombuffer(decoded, pixel_dtype(ds))
 
         if ds.SamplesPerPixel == 1:
             arr = arr.reshape(ds.Rows, ds.Columns)

--- a/rle/tests/test_utils.py
+++ b/rle/tests/test_utils.py
@@ -153,6 +153,13 @@ class TestEncodePixelData:
         with pytest.raises(ValueError, match=msg):
             encode_pixel_data(b'', **kwargs)
 
+    def test_encode_using_dataset(self):
+        """Test encoding using a dataset"""
+        ds = INDEX_LEE["SC_rgb_32bit_2frame.dcm"]['ds']
+        src = ds.pixel_array[0].tobytes()
+        enc = encode_pixel_data(src, ds, "<")
+        assert enc[:10] == b"\x0C\x00\x00\x00\x40\x00\x00\x00\x08\x01"
+
     def test_no_byteorder_u8(self):
         """Test exception raised if invalid byteorder."""
         kwargs = {

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,15 @@
 
-import os
-import sys
+from pathlib import Path
 from setuptools import setup, find_packages
 from setuptools_rust import Binding, RustExtension
 
-import subprocess
-from distutils.command.build import build as build_orig
-import distutils.sysconfig
 
+VERSION_FILE = Path(__file__).parent / "rle" / '_version.py'
+with open(VERSION_FILE) as f:
+    exec(f.read())
 
-
-VERSION_FILE = os.path.join('rle', '_version.py')
-with open(VERSION_FILE) as fp:
-    exec(fp.read())
-
-with open('README.md', 'r') as fp:
-    long_description = fp.read()
+with open('README.md', 'r') as f:
+    long_description = f.read()
 
 setup(
     name = 'pylibjpeg-rle',
@@ -39,15 +33,13 @@ setup(
         "Intended Audience :: Developers",
         "Intended Audience :: Healthcare Industry",
         "Intended Audience :: Science/Research",
-        #"Development Status :: 3 - Alpha",
-        #"Development Status :: 4 - Beta",
         "Development Status :: 5 - Production/Stable",
         "Natural Language :: English",
         "Programming Language :: Rust",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: Linux",
         "Operating System :: Microsoft :: Windows",
@@ -58,7 +50,7 @@ setup(
     package_data = {'': ['*.txt', '*.rs', '*.pyx']},
     include_package_data = True,
     zip_safe = False,
-    python_requires = ">=3.6",
+    python_requires = ">=3.7",
     setup_requires = ['setuptools>=18.0', 'setuptools-rust'],
     install_requires = ["numpy"],
     extras_require = {


### PR DESCRIPTION
* Add support for Python 3.10, remove support for Python 3.6
* Strip excess padding from decoded segments (closes #7)